### PR TITLE
feat: support most-significant-bit first

### DIFF
--- a/nl2bench/__main__.py
+++ b/nl2bench/__main__.py
@@ -37,6 +37,11 @@ from .nl2bench import verilog_netlist_to_bench
     multiple=True,
     type=str,
 )
+@click.option(
+    "--msb-first/--lsb-first",
+    default=False,
+    type=bool,
+)
 @click.argument(
     "netlist_in",
     type=click.Path(file_okay=True, exists=True),
@@ -46,6 +51,7 @@ def cli(
     netlist_in: str,
     bypassed_ports: Iterable[str],
     lib_files: Iterable[str],
+    msb_first: bool,
 ):
     if output is None:
         output = netlist_in
@@ -54,7 +60,11 @@ def cli(
         output = f"{output}.bench"
     with open(output, "w", encoding="utf8") as f:
         verilog_netlist_to_bench(
-            Path(netlist_in), lib_files, f, bypass_ios=set(bypassed_ports)
+            Path(netlist_in),
+            lib_files,
+            f,
+            bypass_ios=set(bypassed_ports),
+            msb_first=msb_first,
         )
     print(f"Successfully saved to {output}.")
 

--- a/nl2bench/nl2bench.py
+++ b/nl2bench/nl2bench.py
@@ -109,8 +109,10 @@ def io_to_bench(port: nl_parser.Port, f: TextIOWrapper, msb_first: bool = False)
 def statements_to_bench(inst: nl_parser.Instance, base: Cell, f: TextIOWrapper):
     for output, function in base.outputs.items():
         if hooked := inst.io.get(output):
+            # HACK FOR SKY130
+            if function is None and inst.kind.startswith("sky130_fd_sc_hd__dlclkp_"):
+                function = "1"
             transform_function_rec(hooked, function, inst, f)
-
 
 def netlist_to_bench(
     netlist: nl_parser.Netlist,

--- a/nl2bench/nl2bench.py
+++ b/nl2bench/nl2bench.py
@@ -114,6 +114,7 @@ def statements_to_bench(inst: nl_parser.Instance, base: Cell, f: TextIOWrapper):
                 function = "1"
             transform_function_rec(hooked, function, inst, f)
 
+
 def netlist_to_bench(
     netlist: nl_parser.Netlist,
     cells: Dict[str, Cell],

--- a/nl2bench/nl2bench.py
+++ b/nl2bench/nl2bench.py
@@ -88,15 +88,22 @@ def transform_function_rec(
         )
 
 
-def io_to_bench(port: nl_parser.Port, f: TextIOWrapper):
+def io_to_bench(port: nl_parser.Port, f: TextIOWrapper, msb_first: bool = False):
     if port.msb is None:
         print(f"{port.direction.upper()}({n(port.name)})", file=f)
     else:
-        frm, to = min(port.msb, port.lsb), max(port.lsb, port.msb)
-        i = frm
-        while i <= to:
-            print(f"{port.direction.upper()}({n(port.name)}[{i}])", file=f)
-            i += 1
+        if msb_first:
+            frm, to = max(port.msb, port.lsb), min(port.lsb, port.msb)
+            i = frm
+            while i >= to:
+                print(f"{port.direction.upper()}({n(port.name)}[{i}])", file=f)
+                i -= 1
+        else:
+            frm, to = min(port.msb, port.lsb), max(port.lsb, port.msb)
+            i = frm
+            while i <= to:
+                print(f"{port.direction.upper()}({n(port.name)}[{i}])", file=f)
+                i += 1
 
 
 def statements_to_bench(inst: nl_parser.Instance, base: Cell, f: TextIOWrapper):
@@ -110,6 +117,7 @@ def netlist_to_bench(
     cells: Dict[str, Cell],
     f: TextIOWrapper,
     bypass_ios: Optional[Set[str]] = None,
+    msb_first: bool = False,
 ):
     bypass_ios = bypass_ios or set()
     print(f"# module {netlist.module}", file=f)
@@ -117,7 +125,7 @@ def netlist_to_bench(
     for port in netlist.ports.values():
         if port.name in bypass_ios:
             continue
-        io_to_bench(port, f)
+        io_to_bench(port, f, msb_first)
     for inst in netlist.instances:
         assert (
             inst.kind in cells
@@ -138,6 +146,7 @@ def verilog_netlist_to_bench(
     lib_files: Iterable[str],
     f: TextIOWrapper,
     bypass_ios: Optional[Set[str]] = None,
+    msb_first: bool = False,
 ):
     cells: Dict[str, Cell] = functools.reduce(
         lambda acc, path: acc.update(Cell.from_lib_file(path)) or acc,
@@ -147,4 +156,4 @@ def verilog_netlist_to_bench(
 
     netlist = nl_parser.parse(netlist_in)
 
-    netlist_to_bench(netlist, cells, f, bypass_ios)
+    netlist_to_bench(netlist, cells, f, bypass_ios, msb_first)

--- a/nl2bench/nl_parser.py
+++ b/nl2bench/nl_parser.py
@@ -100,9 +100,11 @@ def _dump_sigbit(bit: ys.SigBit):
 def parse(verilog_netlist: Path):
     d = ys.Design()
     ys.run_pass(f"read_verilog {shlex.quote(str(verilog_netlist))}", d)
-    ys.run_pass("hierarchy -auto-top")
-    ys.run_pass("flatten")
-    ys.run_pass("splitnets")
+    ys.run_pass("hierarchy -auto-top", d)
+    ys.run_pass("flatten", d)
+    ys.run_pass("splitnets", d)
+    ys.run_pass("opt_clean -purge", d)
+    ys.run_pass("setundef -zero -undriven", d)
 
     ys_module = d.top_module()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "nl2bench"
-version = "0.7.0"
+version = "0.8.0"
 description = "Converts from combinational netlists to the BENCH format for DFT"
 authors = ["Mohamed Gaber <donn@efabless.com>"]
 license = "Apache-2.0"


### PR DESCRIPTION
* Adds `--msb-first`: when unpacking bus inputs declares the most significant bit first. makes the mathematics for test vector assembly slightly easier